### PR TITLE
Fix for TFC 3.2.22

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ jei_version=15.2.0.21
 patchouli_version=4636277
 jade_version=4614153
 firmalife_version=6742946
-tfc_version=5478226
+tfc_version=8063607
 
 
 ## Mod Properties

--- a/src/main/java/com/therighthon/afc/common/NoTrunkStackedTreeFeature.java
+++ b/src/main/java/com/therighthon/afc/common/NoTrunkStackedTreeFeature.java
@@ -35,9 +35,9 @@ public class NoTrunkStackedTreeFeature extends StackedTreeFeature
         final StructureTemplateManager manager = TreeHelpers.getStructureManager(level);
         final StructurePlaceSettings settings = TreeHelpers.getPlacementSettings(level, chunkPos, random);
         if (TreeHelpers.isValidGround(level, pos, settings, config.placement())) {
-            final boolean placeTree = config.rootSystem().map(roots -> TreeHelpers.placeRoots(level, pos.below(), roots, random) || !roots.required()).orElse(true);
+            final boolean placeTree = config.rootSystem().map(roots -> TreeHelpers.placeRoots(level, pos.below().mutable(), roots, random) || !roots.required()).orElse(true);
             if (placeTree) {
-                config.rootSystem().ifPresent(roots -> TreeHelpers.placeRoots(level, pos.below(), roots, random));
+                config.rootSystem().ifPresent(roots -> TreeHelpers.placeRoots(level, pos.below().mutable(), roots, random));
                 for (StackedTreeConfig.Layer layer : config.layers()) {
                     // Place each layer
                     int layerCount = layer.getCount(random);


### PR DESCRIPTION
### What is the new behavior?
Fixes a change made in TFC 3.2.22 to TreeHelpers. It now takes BlockPos.MutableBlockPos instead of BlockPos. 

### Implementation
It is a very simple fix of changing `pos.below()` to `pos.below().mutable()` in `NoTrunkStackedTreeFeature.java`, but I did not find any particular issues with this method.